### PR TITLE
Set cookie session to 30 days

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -53,7 +53,8 @@ class XWingSquadDatabase < Sinatra::Base
 
     # Middleware
 
-    use Rack::Session::Cookie, :secret => ENV['SESSION_SECRET']
+    use Rack::Session::Cookie,  :expire_after => 2592000,
+                                :secret => ENV['SESSION_SECRET']
 
     use OmniAuth::Builder do
         PROVIDERS.each do |provider_name, provider_args|


### PR DESCRIPTION
Added additional parameter to set the cookie session to 30 days. if not set, the cookie is default to remove itself when the browser closes itself.